### PR TITLE
buffer user lags and send them in batch during tick

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use smallvec::SmallVec;
+use std::collections::HashMap;
 
 use crate::model::{Flag, GameId, Sri, UserId, InvalidUserId};
 
@@ -96,7 +97,7 @@ pub enum LilaIn<'a> {
     Watch(&'a GameId),
     Unwatch(&'a GameId),
     Connections(u32),
-    Lag(&'a UserId, u32),
+    Lags(&'a HashMap::<UserId, u32>),
     Friends(&'a UserId),
     TellSri(&'a Sri, Option<&'a UserId>, &'a str),
 }
@@ -111,7 +112,13 @@ impl<'a> fmt::Display for LilaIn<'a> {
             LilaIn::Watch(game) => write!(f, "watch {}", game),
             LilaIn::Unwatch(game) => write!(f, "unwatch {}", game),
             LilaIn::Connections(n) => write!(f, "connections {}", n),
-            LilaIn::Lag(uid, lag) => write!(f, "lag {} {}", uid, lag),
+            LilaIn::Lags(lags) => {
+                let mut s = String::new();
+                for (uid, lag) in lags.iter() { 
+                    s.push_str(format!("{}:{},", uid, lag).as_str())
+                }
+                write!(f, "lags {}", s)
+            }
             LilaIn::Friends(uid) => write!(f, "friends {}", uid),
             LilaIn::TellSri(sri, uid, payload) =>
                 write!(f, "tell/sri {} {} {}", sri, uid.map_or("-", |u| u.as_str()), payload),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -113,11 +113,11 @@ impl<'a> fmt::Display for LilaIn<'a> {
             LilaIn::Unwatch(game) => write!(f, "unwatch {}", game),
             LilaIn::Connections(n) => write!(f, "connections {}", n),
             LilaIn::Lags(lags) => {
-                let mut s = String::new();
+                write!(f, "lags ")?;
                 for (uid, lag) in lags.iter() { 
-                    s.push_str(format!("{}:{},", uid, lag).as_str())
+                    write!(f, "{}:{},", uid, lag)?;
                 }
-                write!(f, "lags {}", s)
+                Ok(())
             }
             LilaIn::Friends(uid) => write!(f, "friends {}", uid),
             LilaIn::TellSri(sri, uid, payload) =>

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,8 +249,9 @@ impl App {
                     max(0, self.connection_count.load(Ordering::Relaxed)) as u32
                 ));
                 // publish the buffered lags and clear them
-                self.publish(LilaIn::Lags(&self.lags.read()));
-                self.lags.write().clear();
+                let mut lags = self.lags.write();
+                self.publish(LilaIn::Lags(&lags));
+                lags.clear();
 
                 // Update stats.
                 self.mlat.store(mlat, Ordering::Relaxed);


### PR DESCRIPTION
`"PUBLISH" "site-in" "lags lizen519:194,lizen505:272,lizen500:231,"`

Because more than half redis messages are about lag

https://monitor.lichess.ovh/d/fQ3rntSWz/lichess-remote-socket?orgId=1&refresh=1m&from=now-6h&to=now&var-period=1m&var-env=prod